### PR TITLE
configuring options merge return defaults on empty

### DIFF
--- a/www/printer.js
+++ b/www/printer.js
@@ -135,8 +135,14 @@ exports.print = function (content, options, callback, scope) {
 exports.mergeWithDefaults = function (options) {
     var defaults = this.getDefaults();
 
-    if( options === undefined ){
-        return this.getDefaults();
+    //check if options are empty
+    if( options === undefined
+          || options == undefined
+          || options == null
+          || JSON.stringify(options) == "undefined"
+          || JSON.stringify(options) === undefined
+          || JSON.stringify(options) === JSON.stringify({}) ){
+      return defaults;
     }
     
     if (options.bounds && !options.bounds.length) {


### PR DESCRIPTION
Issues arose when attempting to perform "pick" requests since the latest version (Typescript) of the plugin doesn't provide a means of sending options.